### PR TITLE
修复中英文切换bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN set -x \
     && apk add bash \
     && apk add tzdata \
     && apk add gcc \
+    && apk add gettext \
     && apk add libc-dev \
     && apk add linux-headers \
     && apk add nginx \


### PR DESCRIPTION
django国际化时，由于容器内少安装了gettext导致无法正常进行切换，需要增加gettext包